### PR TITLE
ナビのレスポンシブ修正、アカウント情報修正機能追加

### DIFF
--- a/src/components/Category.tsx
+++ b/src/components/Category.tsx
@@ -10,17 +10,17 @@ import CategoryStyle from "../styles/category/category.module.scss";
 import { useDispatch } from "react-redux";
 import { categoryId } from "../features/postSlice";
 import { useLocation } from "react-router-dom";
-import { CategoryData } from "../types/Types";
+import { CategoryData, PostState } from "../types/Types";
 
 const Category = forwardRef((props, ref) => {
   const { state } = useLocation();
   const location = useLocation();
   const currentLocation = location.pathname;
-  const categoryState = state;
+  const categoryState: PostState = state;
   const dispatch = useDispatch();
 
   //編集画面の場合のみ初期値をいれる
-  const [postedCategory, setpostedCategory] = useState(
+  const [postedCategory, setpostedCategory] = useState<string>(
     !currentLocation.startsWith("/home") ? categoryState?.category.name : "食費"
   );
 

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -8,7 +8,7 @@ import Cookies from "js-cookie";
 import toastItem from "./modal/Toast";
 
 const Navigation = () => {
-  const [editModalIsOpen, setEditModalIsOpen] = useState(false);
+  const [editModalIsOpen, setEditModalIsOpen] = useState<boolean>(false);
   const cookie = document.cookie;
   const navigate = useNavigate();
 
@@ -29,8 +29,8 @@ const Navigation = () => {
   };
   return (
     <>
-      <div>
-        <nav className={NaviStyles.naviContainer}>
+      <div className={NaviStyles.naviContainer}>
+        <nav>
           <Link to="/home">
             {/* <h1>家計簿</h1> */}
             <img src={`${process.env.PUBLIC_URL}/logo2.png`} alt="Logo" />

--- a/src/components/form/emailInput.tsx
+++ b/src/components/form/emailInput.tsx
@@ -1,17 +1,52 @@
-import FormStyle from "../../styles/form/formStyle.module.scss"
-import { useDispatch } from 'react-redux'
-import { addEmail } from '../../features/formSlice'
+import FormStyle from "../../styles/form/formStyle.module.scss";
+import { useDispatch } from "react-redux";
+import { addEmail } from "../../features/formSlice";
+import { ChangeEvent, useEffect, useState } from "react";
+import { useLocation } from "react-router-dom";
 
+type EmailInputProps = {
+  userEmail: string;
+};
 
-const EmailInput=()=> {
-  const dispatch =useDispatch();
+const EmailInput = (props: EmailInputProps) => {
+  const { userEmail } = props;
+  const dispatch = useDispatch();
+  const location = useLocation();
+  const currentLocation = location.pathname;
+  const [initialEmail, setInitialEmail] = useState(
+    currentLocation.startsWith("/account") ? userEmail : ""
+  );
+
+  useEffect(() => {
+    setInitialEmail(currentLocation.startsWith("/account") ? userEmail : "");
+  }, [currentLocation, userEmail]);
+
+  useEffect(() => {
+    if (initialEmail === userEmail) {
+      dispatch(addEmail(userEmail));
+    } else {
+      dispatch(addEmail(initialEmail));
+    }
+  });
+
+  const changeEmail = (e: ChangeEvent<HTMLInputElement>) => {
+    setInitialEmail(e.target.value);
+    dispatch(addEmail(e.target.value));
+  };
+
   return (
-  <>
-  <div className={FormStyle.inputMain}><input type="email" id="email" placeholder='メールアドレス入力してください' onChange={
-(e:any)=>dispatch(addEmail(e.target.value))  
-  } /></div>
-  </>
-  )
-}
+    <>
+      <div className={FormStyle.inputMain}>
+        <input
+          type="email"
+          id="email"
+          value={initialEmail || ""} // 初期値がundefinedの場合に空の文字列を設定する
+          placeholder="メールアドレス入力してください"
+          onChange={changeEmail}
+        />
+      </div>
+    </>
+  );
+};
 
 export default EmailInput;

--- a/src/components/form/passwordInput.tsx
+++ b/src/components/form/passwordInput.tsx
@@ -1,16 +1,29 @@
-import React from "react";
+import React, { ChangeEvent, forwardRef, useImperativeHandle } from "react";
 import FormStyle from "../../styles/form/formStyle.module.scss";
 import { useDispatch } from "react-redux";
 import { addPassword } from "../../features/formSlice";
 import { useState } from "react";
 import AddBoxIcon from "@mui/icons-material/AddBox";
-const PasswordInput = () => {
+
+const PasswordInput = forwardRef((props, ref) => {
   const [passwordShown, setPasswordShown] = useState(false);
+  const [password, setPassword] = useState("");
   const dispatch = useDispatch();
   const [isRevealPassword, setIsRevealPassword] = useState(false);
   const togglePassword = () => {
     setIsRevealPassword((prevState) => !prevState);
   };
+
+  const handlePassword = (e: ChangeEvent<HTMLInputElement>) => {
+    setPassword(e.target.value);
+    dispatch(addPassword(e.target.value));
+  };
+
+  useImperativeHandle(ref, () => ({
+    clearPass: () => {
+      setPassword("");
+    },
+  }));
   return (
     <>
       <div className={FormStyle.inputMain}>
@@ -18,7 +31,8 @@ const PasswordInput = () => {
           type={passwordShown ? "text" : "password"}
           placeholder="パスワードを入力してください"
           id="password"
-          onChange={(e: any) => dispatch(addPassword(e.target.value))}
+          value={password}
+          onChange={handlePassword}
         />
         <span
           onClick={togglePassword}
@@ -41,6 +55,6 @@ const PasswordInput = () => {
       </div> */}
     </>
   );
-};
+});
 
 export default PasswordInput;

--- a/src/components/form/reportForm.tsx
+++ b/src/components/form/reportForm.tsx
@@ -8,18 +8,13 @@ import React, {
 import reportPostStyle from "../../styles/reportPost/reportPost.module.scss";
 import { inputDate, inputPrice, inputMemo } from "../../features/postSlice";
 import { useDispatch } from "react-redux";
-import { Link, useLocation } from "react-router-dom";
-import { ArrowLeft } from "phosphor-react";
+import { useLocation } from "react-router-dom";
 import moment from "moment";
 
 const ReportForm = forwardRef((props, ref) => {
   const location = useLocation();
   const currentLocation = location.pathname;
   const dispatch = useDispatch();
-
-  // const reportAlert = useSelector((state: RootState) => state.posts.alert);
-
-  console.log(props, 81);
 
   //詳細ページからのデータ受け取り
   const { state } = useLocation();
@@ -29,13 +24,13 @@ const ReportForm = forwardRef((props, ref) => {
   const todayDate = new Date();
 
   //パスによって初期値変更
-  const [memo, setMemo] = useState(
+  const [memo, setMemo] = useState<string>(
     currentLocation.startsWith("/edit") ? postState?.content : ""
   );
   const [price, setPrice] = useState(
     currentLocation.startsWith("/edit") ? postState?.price : 0
   );
-  const [date, setDate] = useState(
+  const [date, setDate] = useState<string>(
     currentLocation.startsWith("/edit")
       ? postDate
       : moment(todayDate).format("YYYY-MM-DD")
@@ -67,6 +62,7 @@ const ReportForm = forwardRef((props, ref) => {
     }
   };
 
+  //e.target.valueAsNumber
   const handleExpence = (e: ChangeEvent<HTMLInputElement>) => {
     setPrice(e.target.value);
     if (e.target.value !== postState?.price) {
@@ -97,15 +93,6 @@ const ReportForm = forwardRef((props, ref) => {
 
   return (
     <div className={reportPostStyle.container}>
-      {currentLocation.startsWith("/edit") ? (
-        <div className={reportPostStyle.returnIcon}>
-          <Link to={`/report/${postState.category.id}`}>
-            <ArrowLeft />
-          </Link>
-        </div>
-      ) : (
-        ""
-      )}
       <form>
         <div className={reportPostStyle.postList}>
           <label htmlFor="date">日付</label>

--- a/src/features/postSlice.tsx
+++ b/src/features/postSlice.tsx
@@ -22,12 +22,9 @@ export const postSlice = createSlice({
     categoryId: (state, action: PayloadAction<number>) => {
       state.category = action.payload;
     },
-    alertMsg: (state) => {
-      state.alert = !state.alert;
-    },
   },
 });
 
-export const { inputDate, inputPrice, inputMemo, categoryId, alertMsg } =
+export const { inputDate, inputPrice, inputMemo, categoryId } =
   postSlice.actions;
 export default postSlice.reducer;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -62,7 +62,7 @@ const Login = () => {
   return (
     <>
       <DefaultLayout>
-        <EmailInput />
+        <EmailInput userEmail="" />
         <PasswordInput />
         {error}
         <PrimaryButton

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -90,7 +90,7 @@ const Register = () => {
   return (
     <>
       <DefaultLayout>
-        <EmailInput />
+        <EmailInput userEmail="" />
         {alertEmailMessage ? <p>メールアドレスを入力してください</p> : ""}
         {alertExitEmail ? <p>すでに登録されているメールアドレスです</p> : ""}
         <PasswordInput />

--- a/src/pages/ReportCategory.tsx
+++ b/src/pages/ReportCategory.tsx
@@ -43,6 +43,7 @@ const ReportCategory = () => {
   const filterDate = filterCategory?.filter(
     (post) => post.updatedAt.slice(0, 7) === selectedDate
   );
+  console.log(filterDate, 189);
 
   return (
     <DefaultLayout>

--- a/src/pages/ReportEdit.tsx
+++ b/src/pages/ReportEdit.tsx
@@ -14,7 +14,7 @@ import { RootState } from "../types/Types";
 import Cookies from "js-cookie";
 
 const ReportEdit: React.FC = () => {
-  const [editModalIsOpen, setEditModalIsOpen] = useState(false);
+  const [editModalIsOpen, setEditModalIsOpen] = useState<boolean>(false);
 
   const reportDate = useSelector((state: RootState) => state.posts.date);
   const reportPrice = useSelector((state: RootState) => state.posts.expence);

--- a/src/styles/navigation/navigation.module.scss
+++ b/src/styles/navigation/navigation.module.scss
@@ -11,10 +11,16 @@ $breakpoints: (
 }
 
 .naviContainer {
-  display: flex;
-  justify-content: space-between;
+  // display: flex;
+  // justify-content: space-between;
+  width: 100%;
   padding: 5px 20px;
+  margin: auto;
   background-color: #dddddd;
+  nav {
+    display: flex;
+    justify-content: space-between;
+  }
   h1 {
     @include mq(sp) {
       display: none;
@@ -39,16 +45,20 @@ $breakpoints: (
 
 .naviList {
   display: flex;
-  width: 30%;
-  justify-content: space-around;
+  justify-content: right;
+  width: 45%;
   @include mq(sp) {
     margin: 0 auto;
+    justify-content: space-around;
   }
   li {
     list-style-type: none;
     text-align: center;
     font-size: 12px;
+    margin: 0 10px;
     svg {
+      width: 100%;
+      height: 70%;
       transition: all 0.3s;
     }
     p {
@@ -60,12 +70,14 @@ $breakpoints: (
     }
     @include mq(tab) {
       font-size: 10px;
+      margin: 0;
     }
     @include mq(sp) {
       width: 100px;
       text-align: center;
       padding: 0 20px;
       font-size: 10px;
+      margin: 0;
     }
   }
   li:hover {

--- a/src/types/Types.tsx
+++ b/src/types/Types.tsx
@@ -11,15 +11,13 @@ export type FormState = {
 };
 
 export type PostState = {
-  state: {
-    authorId: number;
-    category: { id: number; name: string };
-    categoryId: number;
-    content: string;
-    createdAt: string;
-    price: number;
-    updatedAt: string;
-  };
+  authorId: number;
+  category: { id: number; name: string };
+  categoryId: number;
+  content: string;
+  createdAt: string;
+  price: number;
+  updatedAt: string;
 };
 
 export type PostAll = {
@@ -53,4 +51,11 @@ export type ModalState = {
   setEditModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   onClick: () => void;
   children: string;
+};
+
+export type UserData = {
+  email: string;
+  id: number;
+  password: string;
+  posts: PostState[];
 };


### PR DESCRIPTION
## 対応内容・対応背景・妥協点

- アカウント情報更新機能追加
　現在のメールアドレス初期表示
　post後のパスワードクリア
- ナビゲーションのレスポンシブ修正

## レビュー

想定通りに動作するか？
- /account　
　メールアドレス、パスワード単体での更新ができるか
　/account時のみメールアドレスの初期表示
　パスワードハッシュ化
